### PR TITLE
added strong, because i needed it :-)

### DIFF
--- a/CJAMacros.podspec
+++ b/CJAMacros.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
  s.name         = "CJAMacros"
- s.version      = "2.0.3"
+ s.version      = "2.0.4"
  s.platform     = :ios, "6.0"
  s.summary      = "Macro collection for daily usage"
  s.homepage     = "https://github.com/carlj/CJAMacros"

--- a/CJAMacros/CJAMacros.h
+++ b/CJAMacros/CJAMacros.h
@@ -266,6 +266,21 @@ Add a Singelton implementation to the .m File
 #define CJAWeakSelf CJAWeak(self)
 
 /**
+ Define a strong for an object with a given name.
+ */
+#define CJAStrongWithNameAndObject(_obj, _name) __strong typeof(_obj) strong##_name = _obj
+
+/**
+ Define a strong for a given object.
+ */
+#define CJAStrong(_obj) CJAStrongWithNameAndObject(_obj, _obj)
+
+/**
+ Define a strong self.
+ */
+#define CJAStrongSelf CJAStrong(self)
+
+/**
  Typicall isKindOfClass Check
  */
 #define CJAIsKindOfClass(_object, _class) [_object isKindOfClass: [_class class]]

--- a/Example/Classes/DemoViewController.m
+++ b/Example/Classes/DemoViewController.m
@@ -124,15 +124,25 @@ CJAMacrosSingletonImplemantion
     CJAWeakSelf;
     NSAssert([weakself isEqual:self], @"Objects should be equal");
 
+    CJAStrongSelf;
+    NSAssert([strongself isEqual:self], @"Objects should be equal");
+    
     // Test weak strings.
     NSString *text = @"Example";
     CJAWeak(text);
     NSAssert([weaktext isEqual:text], @"NSString objects should be equal");
-    
+
+    CJAStrong(text);
+    NSAssert([strongtext isEqual:text], @"NSString objects should be equal");
+
     // Test weak numbers
     NSNumber *number = @(1);
     CJAWeakWithNameAndObject(number, Number);
     NSAssert([weakNumber isEqual:number], @"NSNumber objects should be equal");
+    
+    CJAStrongWithNameAndObject(number, Number);
+    NSAssert([strongNumber isEqual:number], @"NSNumber objects should be equal");
+    
 }
 
 - (void)perfomKindOfClassChecks {


### PR DESCRIPTION
Hey Carl,
please add my pull request with the support for strong self macros :-)

reason a weakself inside a block can become nil after the first usage,
so we need strongself, if we like to execute more than two thins on self

details here:
http://albertodebortoli.github.io/blog/2013/08/03/objective-c-blocks-caveat/
http://dhoerl.wordpress.com/2013/04/23/i-finally-figured-out-weakself-and-strongself/
