### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Collection of daily used Macros in my iOS Projects
 [![Build Status](https://travis-ci.org/carlj/CJAMacros.png?branch=master)](https://travis-ci.org/carlj/CJAMacros)
 
 ##Installation
-Just drag&drop the ```CJAMarcos.h``` file in your XCode Project. 
+Just drag&drop the ```CJAMarcos.h``` file in your Xcode Project. 
 For global usage you can import the ```CJAMarcos.h``` in your projects ```-Prefix.pch``` file.
 
 ##Usage


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
